### PR TITLE
configurable DEFAULT_SUBSTRATE_URL from env, remove deprecated address_type

### DIFF
--- a/gsy_dex/trade_store/__init__.py
+++ b/gsy_dex/trade_store/__init__.py
@@ -15,10 +15,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
-DEFAULT_SUBSTRATE_URL = "wss://verifier-node.dev.gridsingularity.com/"
-TEMPLATE_NODE_ADDRESS_TYPE = 42
-
 custom_type_registry = {
     "runtime_id": 2000,
     "types": {

--- a/gsy_dex/trade_store/constants.py
+++ b/gsy_dex/trade_store/constants.py
@@ -2,6 +2,9 @@ import os
 
 mnemonic = os.environ.get("SUBSTRATE_MNEMONIC", "MNEMONIC_TO_RESTORE_YOUR_KEYPAIR")
 
+DEFAULT_SUBSTRATE_URL = os.getenv('DEFAULT_SUBSTRATE_URL',"wss://verifier-node.dev.gridsingularity.com/")
+TEMPLATE_NODE_ADDRESS_TYPE = os.getenv('TEMPLATE_NODE_ADDRESS_TYPE',42)
+
 BC_NUM_FACTOR = 10 ** 12
 BOB_STASH_ADDRESS = "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc"
 ALICE_STASH_ADDRESS = "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY"
@@ -12,4 +15,3 @@ default_call_module = 'Tradestorage'
 default_call_function = 'store_trade_map'
 default_energy: 1 * BC_NUM_FACTOR
 default_rate = 12
-address_type = 42

--- a/gsy_dex/trade_store/market_interface.py
+++ b/gsy_dex/trade_store/market_interface.py
@@ -19,11 +19,11 @@ import logging
 import uuid
 from datetime import datetime
 
-from gsy_dex.trade_store import (
-    DEFAULT_SUBSTRATE_URL, template_type_registry, TEMPLATE_NODE_ADDRESS_TYPE)
+from gsy_dex.trade_store import template_type_registry
 from gsy_dex.trade_store.constants import (
     mnemonic, BOB_STASH_ADDRESS, ALICE_STASH_ADDRESS, ENERGY_SCALING_FACTOR, RATE_SCALING_FACTOR,
-    default_call_module, default_call_function, address_type)
+    default_call_module, default_call_function,
+    TEMPLATE_NODE_ADDRESS_TYPE, DEFAULT_SUBSTRATE_URL)
 from substrateinterface import Keypair  # NOQA
 from substrateinterface import SubstrateInterface
 from substrateinterface.exceptions import SubstrateRequestException
@@ -37,13 +37,13 @@ class SubstrateBlockchainInterface:
         self.simulation_id = simulation_id
         self.substrate = SubstrateInterface(
             url=DEFAULT_SUBSTRATE_URL,
-            address_type=TEMPLATE_NODE_ADDRESS_TYPE,
+            ss58_format=TEMPLATE_NODE_ADDRESS_TYPE,
             type_registry_preset='substrate-node-template',
             type_registry=template_type_registry
         )
 
     def load_keypair(self):
-        return Keypair.create_from_mnemonic(mnemonic, address_type=address_type)
+        return Keypair.create_from_mnemonic(mnemonic, ss58_format=TEMPLATE_NODE_ADDRESS_TYPE)
 
     def compose_call(self, call_module, call_function, call_params):
         call = self.substrate.compose_call(


### PR DESCRIPTION
The Substrate_URL wasn't configurable until now.
This change allows to integrate local substrate blockchains for development purposes